### PR TITLE
Support for looking up parent values from within loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ var result = Mark.up(template, context);
 // "<ul><li>Jill</li><li>Jen</li></ul>"
 ```
 
+Referring to properties outside the loop:
+To refer to properties outside the loop prefix the expression with a dot (dot at the beginning indicates absolute path from root)
+
+``` javascript
+var context = {
+    school: 'Stanford',
+    sisters: [
+        {name: {first: "Jill", last: "Doe"}},
+        {name: {first: "Jen", last: "Doe"}}
+    ]
+};
+
+var template = "<ul>{{sisters}}<li>{{name.first}} is in {{.school}}</li>{{/sisters}}</ul>";
+
+var result = Mark.up(template, context);
+// "<ul><li>Jill is in Stanford</li><li>Jen is in Stanford</li></ul>"
+```
+
+
 ### Loop counters
 
 Inside a loop, a single hash sign refers to the current iteration index

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "markup-js",
-    "version": "1.5.21",
+    "version": "1.5.22",
     "description": "Markup.js - Powerful JavaScript Templates",
     "homepage": "https://github.com/adammark/Markup.js",
     "author": {

--- a/src/markup.js
+++ b/src/markup.js
@@ -265,35 +265,34 @@ Mark.up = function (template, context, options) {
             result = this._pipe(context, filters, options);
         }
 
-        // Evaluating a variable with dot notation, e.g. "a.b.c"
+        // Evaluating a variable with dot notation, e.g. "a.b.c"       
         else if (prop.indexOf(".") > -1) {
             prop = prop.split(".");
             var rootMode = false;
             if (prop[0] === '') {
-                ctx = options.rootContext;
                 prop = prop.splice(1, prop.length);                
                 rootMode = true;
-            } else {
-                ctx = Mark.globals[prop[0]];
-                if (ctx) {
-                    j = 1;
-                }
-                else {
-                    j = 0;
+            }
+            ctx = Mark.globals[prop[0]];
+            
+            if (ctx) {
+                j = 1;
+            }
+            else {
+                j = 0;
+                if (rootMode) {
+                    ctx = options.rootContext;
+                } else {
                     ctx = context;
                 }
             }
+
             // Get the actual context
-            while (ctx && j < prop.length) {                
+            while (ctx && j < prop.length) {
                 ctx = ctx[prop[j++]];
-                if (rootMode) {
-                    //console.log(ctx);
-                }
             }
-            if (rootMode) {
-                console.log(prop, ctx, j);              
-            }            
-            result = this._eval(ctx, filters, child, options);                        
+
+            result = this._eval(ctx, filters, child);
         }
 
         // Evaluating an "if" statement.

--- a/test/spec/MarkupSpec.js
+++ b/test/spec/MarkupSpec.js
@@ -384,6 +384,18 @@ describe("Markup core spec", function () {
         result = Mark.up(template, context);
         expect(result).toEqual("sisters: <li>Jill</li><li>Jen</li>");
     });
+    
+    it("resolves referring to outer elements within array", function () {
+        template = "sisters: {{sisters}}<li>{{name}} - {{.zip}}</li>{{/sisters}}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("sisters: <li>Jill - 12345</li><li>Jen - 12345</li>");
+    });
+    
+    it("resolves referring to nested outer elements within array", function () {
+        template = "sisters: {{sisters}}<li>{{name}} - {{.friend.friend.name}} and {{.brothers.0}}</li>{{/sisters}}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("sisters: <li>Jill - Jeremy and Jack</li><li>Jen - Jeremy and Jack</li>");
+    });
 
     it("resolves iteration using dot notation", function () {
         template = "{{alpha.beta}}{{.}}{{/alpha.beta}}";

--- a/test/spec/MarkupSpec.js
+++ b/test/spec/MarkupSpec.js
@@ -48,8 +48,16 @@ describe("Markup core spec", function () {
         template = "gender: {{ gender }}";
         result = Mark.up(template, context);
         expect(result).toEqual("gender: male");
+        
+        template = "gender: {{ .gender }}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("gender: male");
 
         template = "gender: {{ gender | upcase }}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("gender: MALE");
+        
+        template = "gender: {{ .gender | upcase }}";
         result = Mark.up(template, context);
         expect(result).toEqual("gender: MALE");
 
@@ -116,12 +124,16 @@ describe("Markup core spec", function () {
         template = "{{cousin.name}}{{first}}{{/cousin.name}}";
         result = Mark.up(template, context);
         expect(result).toEqual("Jake");
+        
+        template = "{{cousin}}{{.cousin.name.first}}{{/cousin}}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("Jake");        
     });
 
     it("resolves array index notation", function () {
-        template = "First brother: {{brothers.0}}";
+        template = "First brother: {{brothers.0}} and {{.brothers.0}}";
         result = Mark.up(template, context);
-        expect(result).toEqual("First brother: Jack");
+        expect(result).toEqual("First brother: Jack and Jack");
 
         template = "First sister: {{sisters.0.name}}";
         result = Mark.up(template, context);
@@ -158,8 +170,12 @@ describe("Markup core spec", function () {
         template = "friend's friend: {{friend}}{{friend.name/}}{{/friend}}";
         result = Mark.up(template, context);
         expect(result).toEqual("friend's friend: Jeremy");
-
+        
         template = "brothers: {{brothers|join> + /}} {{brothers}}x{{/brothers}}";
+        result = Mark.up(template, context);
+        expect(result).toEqual("brothers: Jack + Joe + Jim xxx");
+        
+        template = "brothers: {{.brothers|join> + /}} {{.brothers}}x{{/.brothers}}";
         result = Mark.up(template, context);
         expect(result).toEqual("brothers: Jack + Joe + Jim xxx");
     });
@@ -392,9 +408,9 @@ describe("Markup core spec", function () {
     });
     
     it("resolves referring to nested outer elements within array", function () {
-        template = "sisters: {{sisters}}<li>{{name}} - {{.friend.friend.name}} and {{.brothers.0}}</li>{{/sisters}}";
+        template = "Brother: {{brothers.0}} sisters: {{sisters}}<li>{{name}} - {{.friend.friend.name}} and {{.brothers.0}}</li>{{/sisters}}";
         result = Mark.up(template, context);
-        expect(result).toEqual("sisters: <li>Jill - Jeremy and Jack</li><li>Jen - Jeremy and Jack</li>");
+        expect(result).toEqual("Brother: Jack sisters: <li>Jill - Jeremy and Jack</li><li>Jen - Jeremy and Jack</li>");
     });
 
     it("resolves iteration using dot notation", function () {


### PR DESCRIPTION
This introduces a new . prefix that can be used to specify absolute path. This is incredibly useful for performing lookups from within loops. Refer to issue 49.
